### PR TITLE
Fix webhooks "El pago no corresponde a esta tienda"

### DIFF
--- a/app/code/community/Compropago/CpPayment/Model/Observer.php
+++ b/app/code/community/Compropago/CpPayment/Model/Observer.php
@@ -52,7 +52,7 @@ class Compropago_CpPayment_Model_Observer
                 'url'       => $webhook
             );
 
-            // DB insert( prefix."compropago_webhook_transactions",  dataInsert)
+            $DB->insert($prefix."compropago_webhook_transactions",  $dataInsert);
 
 
             /* Retroalimentación en el panel de administración

--- a/app/code/community/Compropago/CpPayment/Model/Standard.php
+++ b/app/code/community/Compropago/CpPayment/Model/Standard.php
@@ -214,7 +214,7 @@ class Compropago_CpPayment_Model_Standard extends Mage_Payment_Model_Method_Abst
                 'ioOut'            => $ioout
             );
 
-            // DB insert ( prefix."compropago_orders",  dataInsert)
+            $DB->insert($prefix."compropago_orders", $dataInsert);
 
             /* TABLE compropago_transactions
              ------------------------------------------------------------------------*/
@@ -229,7 +229,7 @@ class Compropago_CpPayment_Model_Standard extends Mage_Payment_Model_Method_Abst
                 'ioOut'                => $ioout
             );
 
-            // DB insert ( prefix."compropago_transactions",  dataInsert)
+            $DB->insert($prefix."compropago_transactions", $dataInsert);
         } catch (Exception $error) {
             Mage::throwException($error->getMessage());
         }

--- a/app/code/community/Compropago/CpPayment/controllers/IndexController.php
+++ b/app/code/community/Compropago/CpPayment/controllers/IndexController.php
@@ -189,7 +189,7 @@ class Compropago_CpPayment_IndexController extends Mage_Core_Controller_Front_Ac
                 'storeExtra'       => $nomestatus,
             );
 
-            // DBwrite update( prefix."compropago_orders",  updateData, 'id='. res[0]['id'])
+            $DBwrite->update($prefix."compropago_orders",  $updateData, 'id='. $res[0]['id']);
 
 
             /* TABLE compropago_transactions
@@ -204,7 +204,7 @@ class Compropago_CpPayment_IndexController extends Mage_Core_Controller_Front_Ac
                 'ioOut'                => $ioout
             );
 
-            //  DBwrite insert( prefix."compropago_transactions", dataInsert)
+            $DBwrite->insert($prefix."compropago_transactions", $dataInsert);
         } catch (Exception $e) {
             echo $e->getMessage();
         }


### PR DESCRIPTION
Hola

Actualmente no funcionan los webhooks y muestra el siguiente error "El pago no corresponde a esta tienda" esto es debido a que en el actual modulo no esta insertando en bd en las tablas compropago_orders y compropago_transactions.

Tablas que intenta comprobar en el controlador y como no existe genera el siempre el mismo error.

            $sql = "SELECT * FROM " . $prefix . "compropago_orders where compropagoId = '{$response->id}'";
            $res = $DBread->fetchAll($sql);

            $storedId = $res[0]['storeOrderId'];

            if (empty($storedId)) {
               throw new Exception('El pago no corresponde a esta tienda.');
            }

Con el pull request se soluciona dicho error.

Un saludo!